### PR TITLE
Don't multiply GPU profiling times with timer resolution.

### DIFF
--- a/include/CLUtils.hpp
+++ b/include/CLUtils.hpp
@@ -449,9 +449,8 @@ namespace clutils
         GPUTimer (cl::Device &device)
         {
             period tPeriod;
-            size_t tRes = device.getInfo<CL_DEVICE_PROFILING_TIMER_RESOLUTION> ();  // x nanoseconds
             // Converts nanoseconds to seconds and then to the requested scale
-            tUnit = (double) tPeriod.den / (double) tPeriod.num / 1000000000.0 * tRes;
+            tUnit = (double) tPeriod.den / (double) tPeriod.num / 1000000000.0;
         }
 
         /*! \brief Returns a new unpopulated event.


### PR DESCRIPTION
CL_PROFILING_COMMAND_START/CL_PROFILING_COMMAND_END already returns the count in nanoseconds. On some devices CL_DEVICE_PROFILING_TIMER_RESOLUTION returns 1, which can mask the bug.